### PR TITLE
This commit has solved the problem of issue#3.

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -139,16 +139,18 @@ export class BiParser {
       }
     );
 
+    defs.sort((a, b) => { return Number(a.name < b.name) }).reverse()
+
     return {
       fragments: resultFragments,
       defs: defs.map(
         (d) =>
-          ({
-            ...d,
-            path,
-            refs: [],
-            fragment: resultFragments[d.index],
-          } as Definition)
+        ({
+          ...d,
+          path,
+          refs: [],
+          fragment: resultFragments[d.index],
+        } as Definition)
       ),
     };
   }

--- a/test/bimark_longest_match.test.ts
+++ b/test/bimark_longest_match.test.ts
@@ -1,0 +1,19 @@
+import { BiDocError, BiMark, BiParserError } from "../src";
+
+test("longest match", () => {
+    const bm = new BiMark().collect("", `# [[GAN]] [[LayoutGAN]]`);
+    expect(bm.name2def.size).toBe(2);
+    bm.collectRefs('', 'LayoutGAN');
+    expect(bm.name2def.get("GAN")!.refs.length).toBe(0);
+    expect(bm.name2def.get("LayoutGAN")!.refs.length).toBe(1);
+    bm.collectRefs('', 'LayoutGAN');
+    expect(bm.name2def.get("LayoutGAN")!.refs.length).toBe(2);
+    bm.collectRefs('', 'GAN');
+    expect(bm.name2def.get("GAN")!.refs.length).toBe(1);
+    expect(bm.render("", "LayoutGAN").trim()).toBe(
+        '[<span id="layoutgan-ref-3">LayoutGAN</span>](#layoutgan)'
+    );
+    expect(bm.render("", "GAN").trim()).toBe(
+        '[<span id="gan-ref-2">GAN</span>](#gan)'
+    );
+});


### PR DESCRIPTION
Now BiMark can match longest definition first.